### PR TITLE
Watch props rather than data for reactivity

### DIFF
--- a/src/PlaidLink.vue
+++ b/src/PlaidLink.vue
@@ -94,7 +94,7 @@ export default {
         }
     },
     watch: {
-        $data: {
+        $props: {
             handler() {
                 this.onScriptLoaded()
             },


### PR DESCRIPTION
In trying to use your package, I've discovered that you are watching `$data` for reactivity rather than `$props`, which, since the component only has props and no data, is the reverse of what we would like.

This PR fixes this. I don't see any tests here, but this change properly reacts to prop changes in my own app. If you could test, merge, bump the version number, and then release in NPM, that would be great.

Thanks for sharing this package in the first place!